### PR TITLE
Rename warning message variable

### DIFF
--- a/docs/editing_records.md
+++ b/docs/editing_records.md
@@ -98,10 +98,10 @@ To enable these warnings, create a row of Custom Metadata in the
 
 ![Conditional Warning Metadata](images/ConditionalWarningMetadata.png)
 
-| Field                 | Type      | Description                                                                                                                                                                                                  |
-| --------------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| SObject_API_Name\_\_c | Text(255) | API name of the sObject that this conditional warning will be rendered on                                                                                                                                    |
-| Flow_API_Name\_\_c    | Text(255) | The API name of a Flow which will be used to evaluate this warning. The flow must have an input variable called `record` of type sObject record and an output variable called `errorMessage` of type string. If `errorMessage` has a value, then that value will be rendered as a warning to the user. |
+| Field                 | Type      | Description                                                                                                                                                                                                                                                                                                |
+| --------------------- | --------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| SObject_API_Name\_\_c | Text(255) | API name of the sObject that this conditional warning will be rendered on                                                                                                                                                                                                                                  |
+| Flow_API_Name\_\_c    | Text(255) | The API name of a Flow which will be used to evaluate this warning. The flow must have an input variable called `record` of type sObject record and an output variable called `warningMessage` of type string. If `warningMessage` has a value, then that value will be rendered as a warning to the user. |
 
 #### Digital Experience Support
 

--- a/evolve-forms/main/default/classes/DynamicFormsController.cls
+++ b/evolve-forms/main/default/classes/DynamicFormsController.cls
@@ -26,8 +26,6 @@ public with sharing class DynamicFormsController {
   private static final String CREATED_DATE = 'CreatedDate';
   private static final String DATE_STRING = 'Date';
   private static final String DATE_TIME_STRING = 'DateTime';
-  @TestVisible
-  private static final String ERROR_MESSAGE = 'errorMessage';
   private static final String ESCAPED_PERIOD = '\\.';
   private static final String ESCAPED_QUOTE = '\'';
   private static final String GET = 'GET';
@@ -43,6 +41,8 @@ public with sharing class DynamicFormsController {
   private static final String RECORD_VARIABLE = 'record';
   private static final String STRATEGY_NEWEST = 'Newest';
   private static final String STRATEGY_OLDEST = 'Oldest';
+  @TestVisible
+  private static final String WARNING_MESSAGE = 'warningMessage';
 
   private static final String[] EXPECTED_NAME_VALUES = new List<String>{
     NAME, // Most all objects
@@ -97,7 +97,7 @@ public with sharing class DynamicFormsController {
 
   /**
    * @description - Invokes the flow with the specified API name and returns the value
-   * of the `errorMessage` output variable.
+   * of the `warningMessage` output variable.
    * @param record - The state of the current record including all field values
    * from the database as well as the current pending edits.
    * @param flowApiName - the flow to be invoked.
@@ -124,7 +124,7 @@ public with sharing class DynamicFormsController {
       auraException.setMessage(message);
       throw auraException;
     }
-    return (String) flowInterview.getVariableValue(ERROR_MESSAGE);
+    return (String) flowInterview.getVariableValue(WARNING_MESSAGE);
   }
 
   /**

--- a/evolve-forms/main/default/classes/DynamicFormsControllerTest.cls
+++ b/evolve-forms/main/default/classes/DynamicFormsControllerTest.cls
@@ -661,15 +661,15 @@ private with sharing class DynamicFormsControllerTest {
 
   @IsTest
   private static void evaluateConditionalWarningShouldWorkIfEverythingIsConfiguredProperly() {
-    String errorMessage = 'Something is not correct';
+    String warningMessage = 'Something is not correct';
     DynamicFormsController.flowInterview = new DynamicFormsControllerTest.FakeInterview(
       new Map<String, Object>{
-        DynamicFormsController.ERROR_MESSAGE => errorMessage
+        DynamicFormsController.WARNING_MESSAGE => warningMessage
       }
     );
 
     System.assertEquals(
-      errorMessage,
+      warningMessage,
       DynamicFormsController.evaluateConditionalWarning(
         new Account(),
         'Bogus_Flow_API_Name'


### PR DESCRIPTION
Rename the `errorMessage` variable in the conditional warning flow specification to `warningMessage` for improved clarity of intent.