### PR TITLE
Fix the Cancel Button redirect.

### DIFF
--- a/evolve-forms/main/default/lwc/dynamicFormsCreate/dynamicFormsCreate.html
+++ b/evolve-forms/main/default/lwc/dynamicFormsCreate/dynamicFormsCreate.html
@@ -26,7 +26,7 @@
           variant="neutral"
           label="Cancel"
           type="reset"
-          onclick={cancel}
+          onclick={cancelForm}
           class="slds-p-horizontal_small"
         >
         </lightning-button>
@@ -49,7 +49,7 @@
         variant="neutral"
         label="Cancel"
         type="reset"
-        onclick={cancel}
+        onclick={cancelForm}
         class="slds-p-horizontal_small"
       >
       </lightning-button>

--- a/evolve-forms/main/default/lwc/dynamicFormsCreate/dynamicFormsCreate.js
+++ b/evolve-forms/main/default/lwc/dynamicFormsCreate/dynamicFormsCreate.js
@@ -31,6 +31,7 @@ const COMPLETION_EVENT = "completion";
 export default class DynamicFormsCreate extends DynamicFormsSaveCancel {
   @api objectApiName;
   @api buttonLabel = "Submit";
+  @api closeModalOnCancel = false;
   @api successMessage = "Record Created";
   @api includeCancelButton = false;
   @api pinToBottom = false;

--- a/evolve-forms/main/default/lwc/dynamicFormsCreate/dynamicFormsCreate.js
+++ b/evolve-forms/main/default/lwc/dynamicFormsCreate/dynamicFormsCreate.js
@@ -83,4 +83,12 @@ export default class DynamicFormsCreate extends DynamicFormsSaveCancel {
         }
       });
   }
+
+  cancelForm() {
+    if (this.closeModalOnCancel === true) {
+      this.closeAndRedirect(this.objectApiName);
+    } else {
+      this.cancel();
+    }
+  }
 }

--- a/evolve-forms/main/default/lwc/dynamicFormsElement/dynamicFormsElement.js
+++ b/evolve-forms/main/default/lwc/dynamicFormsElement/dynamicFormsElement.js
@@ -157,4 +157,18 @@ export default class DynamicFormsElement extends NavigationMixin(
       }
     });
   }
+
+  // Helper method to navigate to object's list view.
+  navigateToSObject(objectApiName, filterName) {
+    return this[NavigationMixin.Navigate]({
+      type: "standard__objectPage",
+      attributes: {
+        objectApiName: objectApiName,
+        actionName: "list"
+      },
+      state: {
+        filterName: filterName ?? "recent"
+      }
+    });
+  }
 }

--- a/evolve-forms/main/default/lwc/dynamicFormsSaveCancel/dynamicFormsSaveCancel.js
+++ b/evolve-forms/main/default/lwc/dynamicFormsSaveCancel/dynamicFormsSaveCancel.js
@@ -23,7 +23,11 @@ import { getObjectInfo } from "lightning/uiObjectInfoApi";
 import { loadStyle } from "lightning/platformResourceLoader";
 import { ShowToastEvent } from "lightning/platformShowToastEvent";
 import { refreshApex } from "@salesforce/apex";
-import { reduceErrors, invokeUtilityBarApi } from "c/dynamicFormsUtils";
+import {
+  reduceErrors,
+  invokeUtilityBarApi,
+  invokeWorkspaceApi
+} from "c/dynamicFormsUtils";
 import DynamicFormsCSS from "@salesforce/resourceUrl/DynamicFormsCSS";
 import DynamicFormsElement from "c/dynamicFormsElement";
 import getWarnings from "@salesforce/apex/DynamicFormsController.getWarnings";
@@ -159,6 +163,27 @@ export default class DynamicFormsSaveCancel extends DynamicFormsElement {
       }
     }
     return classes.join(" ");
+  }
+
+  closeAndRedirect(objectApiName, filterName) {
+    let focusedTabId;
+    invokeWorkspaceApi(this, "getFocusedTabInfo")
+      .then((focusedTab) => {
+        focusedTabId = focusedTab.tabId;
+        return this.navigateToSObject(objectApiName, filterName);
+      })
+      .then(() => {
+        return invokeWorkspaceApi(this, "closeTab", { tabId: focusedTabId });
+      })
+      .catch((error) => {
+        this.dispatchEvent(
+          new ShowToastEvent({
+            title: "Unable to close the tab.",
+            message: this.generateErrorMessage(error),
+            variant: "error"
+          })
+        );
+      });
   }
 
   cancel() {


### PR DESCRIPTION
Fix: Cancel Button issue

When cancel button was displayed in a Pop-Up window in console mode. Cancel button was only firing a CANCEL event, which makes the UI readable (from editable)