### PR TITLE
DisableCompactLayoutHover option

### DIFF
--- a/evolve-forms/main/default/lwc/dynamicFormsFieldSection/dynamicFormsFieldSection.js
+++ b/evolve-forms/main/default/lwc/dynamicFormsFieldSection/dynamicFormsFieldSection.js
@@ -45,6 +45,7 @@ export default class DynamicFormsFieldSection extends DynamicFormsElement {
   @api labelOverrides = {};
   @api helpTextOverrides = {};
   @api groupOverride = null;
+  @api disableCompactLayoutHover = false;
 
   @track error;
   @track sectionElements;
@@ -214,6 +215,9 @@ export default class DynamicFormsFieldSection extends DynamicFormsElement {
     isLookupFieldInFocus,
     isCompactLayoutInFocus
   ) {
+    if (this.disableCompactLayoutHover) {
+      return;
+    }
     let currentlyHoveringOverLookupField =
       event.currentTarget.getAttribute(DATA_FIELD_API_NAME);
     this.sectionElements

--- a/evolve-forms/main/default/lwc/dynamicFormsFieldSection/dynamicFormsFieldSection.js-meta.xml
+++ b/evolve-forms/main/default/lwc/dynamicFormsFieldSection/dynamicFormsFieldSection.js-meta.xml
@@ -14,6 +14,7 @@
         <targetConfig targets="lightning__RecordPage">
             <property name="sectionLabel" type="String" label="Section Label" description="Enter the label of this section"></property>
             <property name="hideSectionLabelOnView" type="Boolean" label="Hide Section Label on View?" description="Set to true to hide the section label when in view mode."></property>
+            <property name="disableCompactLayoutHover" type="Boolean" label="Disable Compact Layout on Hover?" description="Set to true to disable the compact layout from appearing when hovering over a lookup field."/>
             <property name="readOnlyMode" type="Boolean" label="Set Fields in Read Only mode?" description="Set to true to hide the edit pencil icon when in read only mode."></property>
             <property name="hideSectionLabelOnEdit" type="Boolean" label="Hide Section Label on Edit?" description="Set to true to hide the section label when in edit mode."></property>
             <property name="hideEditHighlighting" type="Boolean" label="Disable Edit Highlights?" description="Set to true to disable highlighting fields that have changed values."></property>
@@ -29,6 +30,7 @@
             <property name="objectApiName" type="String" label="Object API Name" description="Object Api Name"></property>
             <property name="sectionLabel" type="String" label="Section Label" description="Enter the label of this section"></property>
             <property name="hideSectionLabelOnView" type="Boolean" label="Hide Section Label on View?" description="Set to true to hide the section label when in view mode."></property>
+            <property name="disableCompactLayoutHover" type="Boolean" label="Disable Compact Layout on Hover?" description="Set to true to disable the compact layout from appearing when hovering over a lookup field."/>
             <property name="readOnlyMode" type="Boolean" label="Set Fields in Read Only mode?" description="Set to true to hide the edit pencil icon when in read only mode."></property>
             <property name="hideSectionLabelOnEdit" type="Boolean" label="Hide Section Label on Edit?" description="Set to true to hide the section label when in edit mode."></property>
             <property name="hideEditHighlighting" type="Boolean" label="Disable Edit Highlights?" description="Set to true to disable highlighting fields that have changed values."></property>

--- a/evolve-forms/main/default/lwc/dynamicFormsPageLayout/dynamicFormsPageLayout.html
+++ b/evolve-forms/main/default/lwc/dynamicFormsPageLayout/dynamicFormsPageLayout.html
@@ -29,6 +29,7 @@
         label-overrides={labelOverrides}
         help-text-overrides={helpTextOverrides}
         start-in-edit-mode={startInEditMode}
+        disable-compact-layout-hover={disableCompactLayoutHover}
       >
       </c-dynamic-forms-field-section>
     </template>

--- a/evolve-forms/main/default/lwc/dynamicFormsPageLayout/dynamicFormsPageLayout.js
+++ b/evolve-forms/main/default/lwc/dynamicFormsPageLayout/dynamicFormsPageLayout.js
@@ -37,6 +37,7 @@ export default class DynamicFormsPageLayout extends LightningElement {
   @api helpTextOverrides = {};
   @api startInEditMode = false;
   @api boundary = false;
+  @api disableCompactLayoutHover = false;
 
   @track layoutSections;
   @track pageLayoutId;

--- a/evolve-forms/main/default/lwc/dynamicFormsPageLayout/dynamicFormsPageLayout.js-meta.xml
+++ b/evolve-forms/main/default/lwc/dynamicFormsPageLayout/dynamicFormsPageLayout.js-meta.xml
@@ -23,6 +23,12 @@
                 label="Include Boundary?"
                 description="Set to true to include a box around the field sections"
             ></property>
+            <property
+                name="disableCompactLayoutHover"
+                type="Boolean"
+                label="Disable Compact Layout on Hover?"
+                description="Set to true to disable the compact layout from appearing when hovering over a lookup field."
+            ></property>
             <property name="labelOverrides"
                 type="String"
                 label="Field Label Overrides"
@@ -35,6 +41,13 @@
             ></property>
         </targetConfig>
         <targetConfig targets="lightning__AppPage,lightningCommunity__Default">
+            <property
+                name="recordId"
+                type="String"
+                label="Record Id"
+                description="Automatically bind the page's record id to the component variable"
+                default="{!recordId}"
+            ></property>
             <property name="objectApiName"
                 type="String"
                 label="sObject API Name"
@@ -50,6 +63,12 @@
                 type="Boolean"
                 label="Include Boundary?"
                 description="Set to true to include a box around the field sections"
+            ></property>
+            <property
+                name="disableCompactLayoutHover"
+                type="Boolean"
+                label="Disable Compact Layout on Hover?"
+                description="Set to true to disable the compact layout from appearing when hovering over a lookup field."
             ></property>
             <property name="labelOverrides"
                 type="String"


### PR DESCRIPTION
### Adds an option to Field Sections and Page Layouts to disable the Compact Layout on hover
Field Section:
![DisableCompactLayout](https://github.com/google/sf-evolve-forms/assets/12752749/b9306500-ba26-4a27-b13e-a66a2888eb8e)

Page Layout:
![PageLayoutDisableCompactLayout](https://github.com/google/sf-evolve-forms/assets/12752749/76ade9ea-fe28-4f2a-b00c-851def571f95)

### Fixes #27
![EeveeFormHoverFix](https://github.com/google/sf-evolve-forms/assets/12752749/75005332-65e5-4293-9875-c0c20f9c2b03)

- [X] Tests pass
- [X] Appropriate changes to README are included in PR
